### PR TITLE
System dependencies can be specified as build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,27 @@ faas-cli new --lang rstats-http hello-rstats --prefix="<docker-user>"
 the `<docker-user>` means a user or organization on e.g. Docker Hub where
 you have push privileges; don't forget to log in to the registry using `docker login`.
 
+Your folder now should contain the following:
+
+```bash
+hello-rstats/handler.R
+hello-rstats/PACKAGES
+hello-rstats.yml
+```
+
+The `handler.R` file does the heavy lifting by executing the desired
+functionality. `PACKAGES` describes the dependencies.
+The `hello-rstats.yml` is the stack file used to configure functions
+(read more [here](https://docs.openfaas.com/reference/yaml/)).
+
 You can build, push, and deploy the `hello-rstats` function using:
 
 ```bash
 faas-cli up -f hello-rstats.yml
 ```
+
+`faas-cli up` is a [shorthand](https://docs.openfaas.com/cli/templates/)
+for automating `faas-cli build`, `faas-cli push`, and `faas-cli deploy`.
 
 Once the function is deployed, you can test it in the UI (at http://localhost:8080/ui/)
 or using curl:
@@ -73,6 +89,15 @@ For example, calculate principal components
 based on an input data array using the
 [{vegan}](https://CRAN.R-project.org/package=vegan) R package.
 
+The `./hello-rstats/handler.R` file should look like this:
+
+```bash
+handle <- function(req) {
+  x <- jsonlite::fromJSON(paste(req$postBody))
+  vegan::rda(x)$CA$u
+}
+```
+
 Add the {vegan} package to the `./hello-rstats/PACKAGES` file, which now
 looks like this:
 
@@ -89,22 +114,21 @@ Remotes can be defined according to specs in the
 [{remotes}](https://cran.r-project.org/web/packages/remotes/vignettes/dependencies.html)
 package. This includes GitHub, GitLab, Bitbucket etc.
 
-You might also have to add system dependencies to the `Dockerfile`.
+You might also have to add system dependencies for your required packages.
 This is a grey area of the R package ecosystem, see some helpful pointers
-[here](https://github.com/rstudio/r-system-requirements).
-The templates are using the Debian-based `rocker/r-base` Docker image from the
-[rocker](https://github.com/rocker-org) project.
+[here](https://github.com/rstudio/r-system-requirements)
+(the templates are using the Debian-based `rocker/r-base` Docker image from the
+[rocker](https://github.com/rocker-org) project).
 
-The `./hello-rstats/handler.R` file should look like this:
+System dependencies can be added as [build arguments](https://docs.openfaas.com/cli/build/#30-pass-custom-build-arguments) (see how to work with build options
+[here](https://github.com/analythium/openfaas-rstats-templates/issues/10)):
 
 ```bash
-handle <- function(req) {
-  x <- jsonlite::fromJSON(paste(req$postBody))
-  vegan::rda(x)$CA$u
-}
+faas-cli build -f hello-rstats.yml --build-arg ADDITIONAL_PACKAGE="git-core libssl-dev libcurl4-gnutls-dev"
 ```
 
-After `faas-cli up -f hello-rstats.yml` we can test the either in the UI or with curl:
+After pushing and deploying the function,
+we can test the either in the UI or with curl:
 
 ```bash
 curl http://localhost:8080/function/hello-rstats -H \
@@ -114,6 +138,11 @@ curl http://localhost:8080/function/hello-rstats -H \
 
 Now you should see the JSON output
 `[[0.5099,0.5251,-0.4629],[0.479,-0.4319,0.5779],[-0.598,0.4699,0.4143],[-0.391,-0.563,-0.5293]]`.
+
+Note that the of-watchdog HTTP mode loads the handler as a
+very small background web server. The classic watchdog's forking mode in
+would instead load this file for every invocation creating additional latency
+when loading packages or saved data or rained models.
 
 ## Resources
 

--- a/template/rstats-http/Dockerfile
+++ b/template/rstats-http/Dockerfile
@@ -2,8 +2,11 @@ FROM openfaas/of-watchdog:0.7.2 as watchdog
 
 FROM rocker/r-base:latest
 
-# Add here more system dependencies as needed
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Allows you to add additional system dependencies
+ARG ADDITIONAL_PACKAGE
+
+RUN apt-get update && apt-get install -y \
+    --no-install-recommends ${ADDITIONAL_PACKAGE} \
     git-core libssl-dev libcurl4-gnutls-dev \
     && rm -rf /var/lib/apt/lists/*
 

--- a/template/rstats/Dockerfile
+++ b/template/rstats/Dockerfile
@@ -1,10 +1,12 @@
 FROM openfaas/classic-watchdog:0.18.1 as watchdog
 FROM rocker/r-base:latest
 
-# Add system dependencies as needed
-#RUN apt-get update && apt-get install -y --no-install-recommends \
-#    git-core libssl-dev libcurl4-gnutls-dev \
-#    && rm -rf /var/lib/apt/lists/*
+# Allows you to add additional system dependencies
+ARG ADDITIONAL_PACKAGE
+
+RUN apt-get update && apt-get install -y \
+    --no-install-recommends ${ADDITIONAL_PACKAGE} \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN install2.r -e remotes
 


### PR DESCRIPTION
It is possible now to add build arguments or options as the Dockerfile accepts build time ARGs.