### PR TITLE
Streamline templates

### DIFF
--- a/template/rstats-base-ambiorix/Dockerfile
+++ b/template/rstats-base-ambiorix/Dockerfile
@@ -1,5 +1,8 @@
-FROM ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM rocker/r-base:latest
+ARG WATCHDOG_VERSION="0.8.4"
+ARG R_IMAGE="rocker/r-base:latest"
+
+FROM ghcr.io/openfaas/of-watchdog:${WATCHDOG_VERSION} as watchdog
+FROM ${R_IMAGE}
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
@@ -23,22 +26,15 @@ ENV _R_SHLIB_STRIP_=true
 # Install basic dependencies for index.R
 #RUN install2.r -e remotes ambiorix
 # Use gh version for now until JSON parsing is fixed on CRAN
-RUN install2.r -e remotes
+RUN R -q -e 'install.packages(c("remotes"))'
 RUN R -q -e 'remotes::install_github("JohnCoene/ambiorix")'
 
 COPY install.R /usr/local/bin/
 
-# Create a non-root user
-RUN addgroup --system app \
-    && adduser --system --ingroup app app
-
-WORKDIR /home/app
-
-COPY index.R           .
-COPY function          .
+COPY function/DESCRIPTION     .
 
 # Istall SystemRequirements for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$sysreqs()'
 RUN echo requirements.txt
 RUN apt-get update
 RUN xargs -a requirements.txt apt-get install -y --no-install-recommends
@@ -49,7 +45,18 @@ RUN rm requirements.txt
 RUN R -q -e 'remotes::install_deps()'
 
 # Install VersionedPackages for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$versioned()'
+
+RUN rm -f ./DESCRIPTION
+
+# Create a non-root user
+RUN addgroup --system app \
+    && adduser --system --ingroup app app
+
+WORKDIR /home/app
+
+COPY index.R           .
+COPY function          .
 
 # Switch to app user
 RUN chown app:app -R /home/app

--- a/template/rstats-base-beakr/Dockerfile
+++ b/template/rstats-base-beakr/Dockerfile
@@ -1,5 +1,8 @@
-FROM ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM rocker/r-base:latest
+ARG WATCHDOG_VERSION="0.8.4"
+ARG R_IMAGE="rocker/r-base:latest"
+
+FROM ghcr.io/openfaas/of-watchdog:${WATCHDOG_VERSION} as watchdog
+FROM ${R_IMAGE}
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
@@ -21,21 +24,14 @@ COPY Rprofile.site /etc/R
 ENV _R_SHLIB_STRIP_=true
 
 # Install basic dependencies for index.R
-RUN install2.r -e remotes beakr
+RUN R -q -e 'install.packages(c("remotes", "beakr"))'
 
 COPY install.R /usr/local/bin/
 
-# Create a non-root user
-RUN addgroup --system app \
-    && adduser --system --ingroup app app
-
-WORKDIR /home/app
-
-COPY index.R           .
-COPY function          .
+COPY function/DESCRIPTION     .
 
 # Istall SystemRequirements for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$sysreqs()'
 RUN echo requirements.txt
 RUN apt-get update
 RUN xargs -a requirements.txt apt-get install -y --no-install-recommends
@@ -46,7 +42,18 @@ RUN rm requirements.txt
 RUN R -q -e 'remotes::install_deps()'
 
 # Install VersionedPackages for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$versioned()'
+
+RUN rm -f ./DESCRIPTION
+
+# Create a non-root user
+RUN addgroup --system app \
+    && adduser --system --ingroup app app
+
+WORKDIR /home/app
+
+COPY index.R           .
+COPY function          .
 
 # Switch to app user
 RUN chown app:app -R /home/app

--- a/template/rstats-base-fiery/Dockerfile
+++ b/template/rstats-base-fiery/Dockerfile
@@ -1,5 +1,8 @@
-FROM ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM rocker/r-base:latest
+ARG WATCHDOG_VERSION="0.8.4"
+ARG R_IMAGE="rocker/r-base:latest"
+
+FROM ghcr.io/openfaas/of-watchdog:${WATCHDOG_VERSION} as watchdog
+FROM ${R_IMAGE}
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
@@ -21,21 +24,14 @@ COPY Rprofile.site /etc/R
 ENV _R_SHLIB_STRIP_=true
 
 # Install basic dependencies for index.R
-RUN install2.r -e remotes reqres fiery
+RUN R -q -e 'install.packages(c("remotes", "reqres", "fiery"))'
 
 COPY install.R /usr/local/bin/
 
-# Create a non-root user
-RUN addgroup --system app \
-    && adduser --system --ingroup app app
-
-WORKDIR /home/app
-
-COPY index.R           .
-COPY function          .
+COPY function/DESCRIPTION     .
 
 # Istall SystemRequirements for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$sysreqs()'
 RUN echo requirements.txt
 RUN apt-get update
 RUN xargs -a requirements.txt apt-get install -y --no-install-recommends
@@ -46,7 +42,18 @@ RUN rm requirements.txt
 RUN R -q -e 'remotes::install_deps()'
 
 # Install VersionedPackages for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$versioned()'
+
+RUN rm -f ./DESCRIPTION
+
+# Create a non-root user
+RUN addgroup --system app \
+    && adduser --system --ingroup app app
+
+WORKDIR /home/app
+
+COPY index.R           .
+COPY function          .
 
 # Switch to app user
 RUN chown app:app -R /home/app

--- a/template/rstats-base-fiery/README.md
+++ b/template/rstats-base-fiery/README.md
@@ -60,7 +60,7 @@ Use the OpenFaaS UI or curl (should give `["Hello Friend!"]`).
 Replace `localhost` with IP address if testing on remote location:
 
 ```bash
-curl http://localhost:8080/function/<function-name> -d '["Friend"]'
+curl http://localhost:8080/function/<function-name> -H 'Content-Type: application/json' -d '["Friend"]'
 # ["Hello Friend!"]
 ```
 

--- a/template/rstats-base-httpuv/Dockerfile
+++ b/template/rstats-base-httpuv/Dockerfile
@@ -1,5 +1,8 @@
-FROM ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM rocker/r-base:latest
+ARG WATCHDOG_VERSION="0.8.4"
+ARG R_IMAGE="rocker/r-base:latest"
+
+FROM ghcr.io/openfaas/of-watchdog:${WATCHDOG_VERSION} as watchdog
+FROM ${R_IMAGE}
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
@@ -20,20 +23,14 @@ ENV _R_SHLIB_STRIP_=true
 
 # Install basic dependencies for index.R
 # some packages seem to require build from source
-RUN install2.r -e remotes Rcpp httpuv
+RUN R -q -e 'install.packages(c("remotes", "Rcpp", "httpuv"))'
+
 COPY install.R /usr/local/bin/
 
-# Create a non-root user
-RUN addgroup --system app \
-    && adduser --system --ingroup app app
-
-WORKDIR /home/app
-
-COPY index.R           .
-COPY function          .
+COPY function/DESCRIPTION     .
 
 # Istall SystemRequirements for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$sysreqs()'
 RUN echo requirements.txt
 RUN apt-get update
 RUN xargs -a requirements.txt apt-get install -y --no-install-recommends
@@ -44,7 +41,18 @@ RUN rm requirements.txt
 RUN R -q -e 'remotes::install_deps()'
 
 # Install VersionedPackages for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$versioned()'
+
+RUN rm -f ./DESCRIPTION
+
+# Create a non-root user
+RUN addgroup --system app \
+    && adduser --system --ingroup app app
+
+WORKDIR /home/app
+
+COPY index.R           .
+COPY function          .
 
 # Switch to app user
 RUN chown app:app -R /home/app

--- a/template/rstats-base-plumber/Dockerfile
+++ b/template/rstats-base-plumber/Dockerfile
@@ -1,5 +1,8 @@
-FROM ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM rocker/r-base:latest
+ARG WATCHDOG_VERSION="0.8.4"
+ARG R_IMAGE="rocker/r-base:latest"
+
+FROM ghcr.io/openfaas/of-watchdog:${WATCHDOG_VERSION} as watchdog
+FROM ${R_IMAGE}
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
@@ -21,21 +24,14 @@ COPY Rprofile.site /etc/R
 ENV _R_SHLIB_STRIP_=true
 
 # Install basic dependencies for index.R
-RUN install2.r -e remotes plumber
+RUN R -q -e 'install.packages(c("remotes", "plumber"))'
 
 COPY install.R /usr/local/bin/
 
-# Create a non-root user
-RUN addgroup --system app \
-    && adduser --system --ingroup app app
-
-WORKDIR /home/app
-
-COPY index.R           .
-COPY function          .
+COPY function/DESCRIPTION     .
 
 # Istall SystemRequirements for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$sysreqs()'
 RUN echo requirements.txt
 RUN apt-get update
 RUN xargs -a requirements.txt apt-get install -y --no-install-recommends
@@ -46,7 +42,18 @@ RUN rm requirements.txt
 RUN R -q -e 'remotes::install_deps()'
 
 # Install VersionedPackages for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$versioned()'
+
+RUN rm -f ./DESCRIPTION
+
+# Create a non-root user
+RUN addgroup --system app \
+    && adduser --system --ingroup app app
+
+WORKDIR /home/app
+
+COPY index.R           .
+COPY function          .
 
 # Switch to app user
 RUN chown app:app -R /home/app

--- a/template/rstats-base/Dockerfile
+++ b/template/rstats-base/Dockerfile
@@ -1,5 +1,8 @@
-FROM ghcr.io/openfaas/classic-watchdog:0.1.5 as watchdog
-FROM rocker/r-base:latest
+ARG WATCHDOG_VERSION="0.1.5"
+ARG R_IMAGE="rocker/r-base:latest"
+
+FROM ghcr.io/openfaas/classic-watchdog:${WATCHDOG_VERSION} as watchdog
+FROM ${R_IMAGE}
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
@@ -19,17 +22,10 @@ RUN R -q -e 'install.packages(c("remotes", "jsonlite"))'
 
 COPY install.R /usr/local/bin/
 
-# Create a non-root user
-RUN addgroup --system app \
-    && adduser --system --ingroup app app
-
-WORKDIR /home/app
-
-COPY index.R           .
-COPY function          .
+COPY function/DESCRIPTION     .
 
 # Istall SystemRequirements for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$sysreqs()'
 RUN echo requirements.txt
 RUN apt-get update
 RUN xargs -a requirements.txt apt-get install -y --no-install-recommends
@@ -40,7 +36,18 @@ RUN rm requirements.txt
 RUN R -q -e 'remotes::install_deps()'
 
 # Install VersionedPackages for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$versioned()'
+
+RUN rm -f ./DESCRIPTION
+
+# Create a non-root user
+RUN addgroup --system app \
+    && adduser --system --ingroup app app
+
+WORKDIR /home/app
+
+COPY index.R           .
+COPY function          .
 
 # Switch to app user
 RUN chown app:app -R /home/app

--- a/template/rstats-minimal-ambiorix/Dockerfile
+++ b/template/rstats-minimal-ambiorix/Dockerfile
@@ -1,11 +1,14 @@
-FROM ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM rhub/r-minimal:latest
+ARG WATCHDOG_VERSION="0.8.4"
+ARG R_IMAGE="rhub/r-minimal:latest"
+
+FROM ghcr.io/openfaas/of-watchdog:${WATCHDOG_VERSION} as watchdog
+FROM ${R_IMAGE}
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
 # Change options as needed in Rprofile.site
-COPY Rprofile.site /etc/R
+COPY Rprofile.site /usr/local/lib/R/etc/Rprofile.site
 ENV _R_SHLIB_STRIP_=true
 
 # Install system requirements and dependencies for index.R as needed
@@ -19,11 +22,32 @@ RUN installr -d \
     -t "R-dev file linux-headers libxml2-dev gnutls-dev openssl-dev" \
     -a "libxml2" \
     remotes httpuv jsonlite glue fs websocket cli
+
 #RUN installr -e ambiorix
 # Use gh version for now until JSON parsing is fixed on CRAN
 RUN R -q -e 'remotes::install_github("JohnCoene/ambiorix")'
 
 COPY install.R /usr/local/bin/
+
+COPY function/DESCRIPTION     .
+
+# Istall SystemRequirements for handler.R from DESCRIPTION
+RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
+RUN echo requirements.txt
+RUN apk update
+RUN apk add --no-cache gcc musl-dev g++ gfortran linux-headers
+RUN xargs -a requirements.txt apk add
+RUN apk del gcc musl-dev g++ gfortran linux-headers
+RUN rm -rf /var/cache/apk/*
+RUN rm requirements.txt
+
+# Install packages (incl. remotes) for handler.R from DESCRIPTION
+RUN R -q -e 'remotes::install_deps()'
+
+# Install VersionedPackages for handler.R from DESCRIPTION
+RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
+
+RUN rm -f ./DESCRIPTION
 
 # Create a non-root user
 RUN addgroup --system app \
@@ -33,20 +57,6 @@ WORKDIR /home/app
 
 COPY index.R           .
 COPY function          .
-
-# Istall SystemRequirements for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
-RUN echo requirements.txt
-RUN apk update
-RUN xargs -a requirements.txt apk add
-RUN rm -rf /var/cache/apk/*
-RUN rm requirements.txt
-
-# Install packages (incl. remotes) for handler.R from DESCRIPTION
-RUN R -q -e 'remotes::install_deps()'
-
-# Install VersionedPackages for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
 
 # Switch to app user
 RUN chown app:app -R /home/app

--- a/template/rstats-minimal-beakr/Dockerfile
+++ b/template/rstats-minimal-beakr/Dockerfile
@@ -1,11 +1,14 @@
-FROM ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM rhub/r-minimal:latest
+ARG WATCHDOG_VERSION="0.8.4"
+ARG R_IMAGE="rhub/r-minimal:latest"
+
+FROM ghcr.io/openfaas/of-watchdog:${WATCHDOG_VERSION} as watchdog
+FROM ${R_IMAGE}
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
 # Change options as needed in Rprofile.site
-COPY Rprofile.site /etc/R
+COPY Rprofile.site /usr/local/lib/R/etc/Rprofile.site
 ENV _R_SHLIB_STRIP_=true
 
 # Install system requirements and dependencies for index.R as needed
@@ -21,7 +24,28 @@ RUN installr -d \
     -t "R-dev file linux-headers libxml2-dev gnutls-dev openssl-dev" \
     -a "libxml2 icu-libs" \
     remotes beakr
+
 COPY install.R /usr/local/bin/
+
+COPY function/DESCRIPTION     .
+
+# Istall SystemRequirements for handler.R from DESCRIPTION
+RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
+RUN echo requirements.txt
+RUN apk update
+RUN apk add --no-cache gcc musl-dev g++ gfortran linux-headers
+RUN xargs -a requirements.txt apk add
+RUN apk del gcc musl-dev g++ gfortran linux-headers
+RUN rm -rf /var/cache/apk/*
+RUN rm requirements.txt
+
+# Install packages (incl. remotes) for handler.R from DESCRIPTION
+RUN R -q -e 'remotes::install_deps()'
+
+# Install VersionedPackages for handler.R from DESCRIPTION
+RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
+
+RUN rm -f ./DESCRIPTION
 
 # Create a non-root user
 RUN addgroup --system app \
@@ -31,20 +55,6 @@ WORKDIR /home/app
 
 COPY index.R           .
 COPY function          .
-
-# Istall SystemRequirements for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
-RUN echo requirements.txt
-RUN apk update
-RUN xargs -a requirements.txt apk add
-RUN rm -rf /var/cache/apk/*
-RUN rm requirements.txt
-
-# Install packages (incl. remotes) for handler.R from DESCRIPTION
-RUN R -q -e 'remotes::install_deps()'
-
-# Install VersionedPackages for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
 
 # Switch to app user
 RUN chown app:app -R /home/app

--- a/template/rstats-minimal-fiery/Dockerfile
+++ b/template/rstats-minimal-fiery/Dockerfile
@@ -1,11 +1,14 @@
-FROM ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM rhub/r-minimal:latest
+ARG WATCHDOG_VERSION="0.8.4"
+ARG R_IMAGE="rhub/r-minimal:latest"
+
+FROM ghcr.io/openfaas/of-watchdog:${WATCHDOG_VERSION} as watchdog
+FROM ${R_IMAGE}
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
 # Change options as needed in Rprofile.site
-COPY Rprofile.site /etc/R
+COPY Rprofile.site /usr/local/lib/R/etc/Rprofile.site
 ENV _R_SHLIB_STRIP_=true
 
 # Install system requirements and dependencies for index.R as needed
@@ -21,7 +24,28 @@ RUN installr -d \
     -t "R-dev file linux-headers libxml2-dev gnutls-dev openssl-dev" \
     -a "libxml2 icu-libs" \
     remotes reqres fiery
+
 COPY install.R /usr/local/bin/
+
+COPY function/DESCRIPTION     .
+
+# Istall SystemRequirements for handler.R from DESCRIPTION
+RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
+RUN echo requirements.txt
+RUN apk update
+RUN apk add --no-cache gcc musl-dev g++ gfortran linux-headers
+RUN xargs -a requirements.txt apk add
+RUN apk del gcc musl-dev g++ gfortran linux-headers
+RUN rm -rf /var/cache/apk/*
+RUN rm requirements.txt
+
+# Install packages (incl. remotes) for handler.R from DESCRIPTION
+RUN R -q -e 'remotes::install_deps()'
+
+# Install VersionedPackages for handler.R from DESCRIPTION
+RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
+
+RUN rm -f ./DESCRIPTION
 
 # Create a non-root user
 RUN addgroup --system app \
@@ -31,20 +55,6 @@ WORKDIR /home/app
 
 COPY index.R           .
 COPY function          .
-
-# Istall SystemRequirements for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
-RUN echo requirements.txt
-RUN apk update
-RUN xargs -a requirements.txt apk add
-RUN rm -rf /var/cache/apk/*
-RUN rm requirements.txt
-
-# Install packages (incl. remotes) for handler.R from DESCRIPTION
-RUN R -q -e 'remotes::install_deps()'
-
-# Install VersionedPackages for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
 
 # Switch to app user
 RUN chown app:app -R /home/app

--- a/template/rstats-minimal-fiery/README.md
+++ b/template/rstats-minimal-fiery/README.md
@@ -52,7 +52,7 @@ docker run -p 4000:8080 dockeruser/r-minimal-fiery-hello
 Curl should return `["Hello Friend!"]`:
 
 ```bash
-curl http://localhost:4000/ -d '["Friend"]'
+curl http://localhost:4000/ -d '["Friend"]' -H 'Content-Type: application/json'
 # ["Hello Friend!"]
 ```
 

--- a/template/rstats-minimal-httpuv/Dockerfile
+++ b/template/rstats-minimal-httpuv/Dockerfile
@@ -1,11 +1,14 @@
-FROM ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM rhub/r-minimal:latest
+ARG WATCHDOG_VERSION="0.8.4"
+ARG R_IMAGE="rhub/r-minimal:latest"
+
+FROM ghcr.io/openfaas/of-watchdog:${WATCHDOG_VERSION} as watchdog
+FROM ${R_IMAGE}
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
 # Change options as needed in Rprofile.site
-COPY Rprofile.site /etc/R
+COPY Rprofile.site /usr/local/lib/R/etc/Rprofile.site
 ENV _R_SHLIB_STRIP_=true
 
 # Install system requirements and dependencies for index.R as needed
@@ -15,12 +18,34 @@ RUN apk add --no-cache --update-cache \
     --repository http://nl.alpinelinux.org/alpine/v3.11/main \
     autoconf=2.69-r2 \
     automake=1.16.1-r0 \
-    bash gcc
+    bash libsodium libsodium-dev
+
 RUN installr -d \
     -t "R-dev file linux-headers libxml2-dev gnutls-dev openssl-dev" \
     -a "libxml2" \
     remotes httpuv jsonlite
+
 COPY install.R /usr/local/bin/
+
+COPY function/DESCRIPTION     .
+
+# Istall SystemRequirements for handler.R from DESCRIPTION
+RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
+RUN echo requirements.txt
+RUN apk update
+RUN apk add --no-cache gcc musl-dev g++ gfortran linux-headers
+RUN xargs -a requirements.txt apk add
+RUN apk del gcc musl-dev g++ gfortran linux-headers
+RUN rm -rf /var/cache/apk/*
+RUN rm requirements.txt
+
+# Install packages (incl. remotes) for handler.R from DESCRIPTION
+RUN R -q -e 'remotes::install_deps()'
+
+# Install VersionedPackages for handler.R from DESCRIPTION
+RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
+
+RUN rm -f ./DESCRIPTION
 
 # Create a non-root user
 RUN addgroup --system app \
@@ -30,20 +55,6 @@ WORKDIR /home/app
 
 COPY index.R           .
 COPY function          .
-
-# Istall SystemRequirements for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
-RUN echo requirements.txt
-RUN apk update
-RUN xargs -a requirements.txt apk add
-RUN rm -rf /var/cache/apk/*
-RUN rm requirements.txt
-
-# Install packages (incl. remotes) for handler.R from DESCRIPTION
-RUN R -q -e 'remotes::install_deps()'
-
-# Install VersionedPackages for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
 
 # Switch to app user
 RUN chown app:app -R /home/app

--- a/template/rstats-minimal-httpuv/Rprofile.site
+++ b/template/rstats-minimal-httpuv/Rprofile.site
@@ -1,7 +1,7 @@
 local({
     r <- getOption("repos")
-    #r["CRAN"] <- "https://cloud.r-project.org"
-    r["CRAN"] <- "https://packagemanager.rstudio.com/all/__linux__/focal/latest"
+    r["CRAN"] <- "https://cloud.r-project.org"
+    #r["CRAN"] <- "https://packagemanager.rstudio.com/all/__linux__/focal/latest"
     options(repos = r)
     options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version$platform, R.version$arch, R.version$os)))
 })

--- a/template/rstats-minimal-plumber/Dockerfile
+++ b/template/rstats-minimal-plumber/Dockerfile
@@ -1,11 +1,14 @@
-FROM ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM rhub/r-minimal:latest
+ARG WATCHDOG_VERSION="0.8.4"
+ARG R_IMAGE="rhub/r-minimal:latest"
+
+FROM ghcr.io/openfaas/of-watchdog:${WATCHDOG_VERSION} as watchdog
+FROM ${R_IMAGE}
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
 # Change options as needed in Rprofile.site
-COPY Rprofile.site /etc/R
+COPY Rprofile.site /usr/local/lib/R/etc/Rprofile.site
 ENV _R_SHLIB_STRIP_=true
 
 # Install system requirements and dependencies for index.R as needed
@@ -21,7 +24,28 @@ RUN installr -d \
     -t "R-dev file linux-headers libxml2-dev gnutls-dev openssl-dev" \
     -a "libxml2 icu-libs" \
     remotes plumber
+
 COPY install.R /usr/local/bin/
+
+COPY function/DESCRIPTION     .
+
+# Istall SystemRequirements for handler.R from DESCRIPTION
+RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
+RUN echo requirements.txt
+RUN apk update
+RUN apk add --no-cache gcc musl-dev g++ gfortran linux-headers
+RUN xargs -a requirements.txt apk add
+RUN apk del gcc musl-dev g++ gfortran linux-headers
+RUN rm -rf /var/cache/apk/*
+RUN rm requirements.txt
+
+# Install packages (incl. remotes) for handler.R from DESCRIPTION
+RUN R -q -e 'remotes::install_deps()'
+
+# Install VersionedPackages for handler.R from DESCRIPTION
+RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
+
+RUN rm -f ./DESCRIPTION
 
 # Create a non-root user
 RUN addgroup --system app \
@@ -31,20 +55,6 @@ WORKDIR /home/app
 
 COPY index.R           .
 COPY function          .
-
-# Istall SystemRequirements for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
-RUN echo requirements.txt
-RUN apk update
-RUN xargs -a requirements.txt apk add
-RUN rm -rf /var/cache/apk/*
-RUN rm requirements.txt
-
-# Install packages (incl. remotes) for handler.R from DESCRIPTION
-RUN R -q -e 'remotes::install_deps()'
-
-# Install VersionedPackages for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
 
 # Switch to app user
 RUN chown app:app -R /home/app

--- a/template/rstats-minimal/Dockerfile
+++ b/template/rstats-minimal/Dockerfile
@@ -1,5 +1,8 @@
-FROM ghcr.io/openfaas/classic-watchdog:0.1.5 as watchdog
-FROM rhub/r-minimal:latest
+ARG WATCHDOG_VERSION="0.1.5"
+ARG R_IMAGE="rhub/r-minimal:latest"
+
+FROM ghcr.io/openfaas/classic-watchdog:${WATCHDOG_VERSION} as watchdog
+FROM ${R_IMAGE}
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
@@ -19,20 +22,15 @@ RUN installr -d remotes jsonlite
 
 COPY install.R /usr/local/bin/
 
-# Create a non-root user
-RUN addgroup --system app \
-    && adduser --system --ingroup app app
-
-WORKDIR /home/app
-
-COPY index.R           .
-COPY function          .
+COPY function/DESCRIPTION     .
 
 # Istall SystemRequirements for handler.R from DESCRIPTION
 RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
 RUN echo requirements.txt
 RUN apk update
+RUN apk add --no-cache gcc musl-dev g++ gfortran linux-headers
 RUN xargs -a requirements.txt apk add
+RUN apk del gcc musl-dev g++ gfortran linux-headers
 RUN rm -rf /var/cache/apk/*
 RUN rm requirements.txt
 
@@ -42,9 +40,16 @@ RUN R -q -e 'remotes::install_deps()'
 # Install VersionedPackages for handler.R from DESCRIPTION
 RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
 
-# Cleanup
-RUN R -q -e 'remove.packages("remotes")'
-RUN rm /usr/local/bin/install.R
+RUN rm -f ./DESCRIPTION
+
+# Create a non-root user
+RUN addgroup --system app \
+    && adduser --system --ingroup app app
+
+WORKDIR /home/app
+
+COPY index.R           .
+COPY function          .
 
 # Switch to app user
 RUN chown app:app -R /home/app

--- a/template/rstats-ubuntu-ambiorix/Dockerfile
+++ b/template/rstats-ubuntu-ambiorix/Dockerfile
@@ -1,5 +1,8 @@
-FROM ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM rocker/r-ubuntu:18.04
+ARG WATCHDOG_VERSION="0.8.4"
+ARG R_IMAGE="rocker/r-ubuntu:20.04"
+
+FROM ghcr.io/openfaas/of-watchdog:${WATCHDOG_VERSION} as watchdog
+FROM ${R_IMAGE}
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
@@ -24,25 +27,17 @@ ENV _R_SHLIB_STRIP_=true
 
 # Install basic dependencies for index.R
 # some packages seem to require build from source
-RUN R -q -e 'install.packages(c("Rcpp", "stringi", "httpuv"), repos=c(CRAN = "https://cloud.r-project.org"))'
+RUN R -q -e 'install.packages(c("Rcpp", "stringi", "httpuv", "remotes"), repos=c(CRAN = "https://cloud.r-project.org"))'
 #RUN install2.r -e remotes ambiorix
 # Use gh version for now until JSON parsing is fixed on CRAN
-RUN install2.r -e remotes
 RUN R -q -e 'remotes::install_github("JohnCoene/ambiorix")'
 
 COPY install.R /usr/local/bin/
 
-# Create a non-root user
-RUN addgroup --system app \
-    && adduser --system --ingroup app app
-
-WORKDIR /home/app
-
-COPY index.R           .
-COPY function          .
+COPY function/DESCRIPTION     .
 
 # Istall SystemRequirements for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$sysreqs()'
 RUN echo requirements.txt
 RUN apt-get update
 RUN xargs -a requirements.txt apt-get install -y --no-install-recommends
@@ -53,7 +48,18 @@ RUN rm requirements.txt
 RUN R -q -e 'remotes::install_deps()'
 
 # Install VersionedPackages for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$versioned()'
+
+RUN rm -f ./DESCRIPTION
+
+# Create a non-root user
+RUN addgroup --system app \
+    && adduser --system --ingroup app app
+
+WORKDIR /home/app
+
+COPY index.R           .
+COPY function          .
 
 # Switch to app user
 RUN chown app:app -R /home/app

--- a/template/rstats-ubuntu-beakr/Dockerfile
+++ b/template/rstats-ubuntu-beakr/Dockerfile
@@ -1,5 +1,8 @@
-FROM ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM rocker/r-ubuntu:18.04
+ARG WATCHDOG_VERSION="0.8.4"
+ARG R_IMAGE="rocker/r-ubuntu:20.04"
+
+FROM ghcr.io/openfaas/of-watchdog:${WATCHDOG_VERSION} as watchdog
+FROM ${R_IMAGE}
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
@@ -24,22 +27,14 @@ ENV _R_SHLIB_STRIP_=true
 
 # Install basic dependencies for index.R
 # some packages seem to require build from source
-RUN R -q -e 'install.packages(c("Rcpp", "stringi", "httpuv"), repos=c(CRAN = "https://cloud.r-project.org"))'
-RUN install2.r -e remotes beakr
+RUN R -q -e 'install.packages(c("Rcpp", "stringi", "httpuv", "remotes", "beakr"), repos=c(CRAN = "https://cloud.r-project.org"))'
 
 COPY install.R /usr/local/bin/
 
-# Create a non-root user
-RUN addgroup --system app \
-    && adduser --system --ingroup app app
-
-WORKDIR /home/app
-
-COPY index.R           .
-COPY function          .
+COPY function/DESCRIPTION     .
 
 # Istall SystemRequirements for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$sysreqs()'
 RUN echo requirements.txt
 RUN apt-get update
 RUN xargs -a requirements.txt apt-get install -y --no-install-recommends
@@ -50,7 +45,19 @@ RUN rm requirements.txt
 RUN R -q -e 'remotes::install_deps()'
 
 # Install VersionedPackages for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$versioned()'
+
+RUN rm -f ./DESCRIPTION
+
+
+# Create a non-root user
+RUN addgroup --system app \
+    && adduser --system --ingroup app app
+
+WORKDIR /home/app
+
+COPY index.R           .
+COPY function          .
 
 # Switch to app user
 RUN chown app:app -R /home/app

--- a/template/rstats-ubuntu-fiery/Dockerfile
+++ b/template/rstats-ubuntu-fiery/Dockerfile
@@ -1,5 +1,8 @@
-FROM ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM rocker/r-ubuntu:18.04
+ARG WATCHDOG_VERSION="0.8.4"
+ARG R_IMAGE="rocker/r-ubuntu:20.04"
+
+FROM ghcr.io/openfaas/of-watchdog:${WATCHDOG_VERSION} as watchdog
+FROM ${R_IMAGE}
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
@@ -24,22 +27,14 @@ ENV _R_SHLIB_STRIP_=true
 
 # Install basic dependencies for index.R
 # some packages seem to require build from source
-RUN R -q -e 'install.packages(c("Rcpp", "stringi", "httpuv"), repos=c(CRAN = "https://cloud.r-project.org"))'
-RUN install2.r -e remotes reqres fiery
+RUN R -q -e 'install.packages(c("Rcpp", "stringi", "httpuv", "remotes", "reqres", "fiery"), repos=c(CRAN = "https://cloud.r-project.org"))'
 
 COPY install.R /usr/local/bin/
 
-# Create a non-root user
-RUN addgroup --system app \
-    && adduser --system --ingroup app app
-
-WORKDIR /home/app
-
-COPY index.R           .
-COPY function          .
+COPY function/DESCRIPTION     .
 
 # Istall SystemRequirements for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$sysreqs()'
 RUN echo requirements.txt
 RUN apt-get update
 RUN xargs -a requirements.txt apt-get install -y --no-install-recommends
@@ -50,7 +45,19 @@ RUN rm requirements.txt
 RUN R -q -e 'remotes::install_deps()'
 
 # Install VersionedPackages for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$versioned()'
+
+RUN rm -f ./DESCRIPTION
+
+
+# Create a non-root user
+RUN addgroup --system app \
+    && adduser --system --ingroup app app
+
+WORKDIR /home/app
+
+COPY index.R           .
+COPY function          .
 
 # Switch to app user
 RUN chown app:app -R /home/app

--- a/template/rstats-ubuntu-fiery/README.md
+++ b/template/rstats-ubuntu-fiery/README.md
@@ -52,7 +52,7 @@ docker run -p 4000:8080 dockeruser/r-ubuntu-fiery-hello
 Curl should return `["Hello Friend!"]`:
 
 ```bash
-curl http://localhost:4000/ -d '["Friend"]'
+curl http://localhost:4000/ -d '["Friend"]' -H 'Content-Type: application/json'
 # ["Hello Friend!"]
 ```
 

--- a/template/rstats-ubuntu-fiery/README.md
+++ b/template/rstats-ubuntu-fiery/README.md
@@ -76,7 +76,7 @@ Use the OpenFaaS UI or curl (should give `["Hello Friend!"]`).
 Replace `localhost` with IP address if testing on remote location:
 
 ```bash
-curl http://localhost:8080/function/<function-name> -d '["Friend"]'
+curl http://localhost:8080/function/<function-name> -H 'Content-Type: application/json' -d '["Friend"]'
 # ["Hello Friend!"]
 ```
 

--- a/template/rstats-ubuntu-httpuv/Dockerfile
+++ b/template/rstats-ubuntu-httpuv/Dockerfile
@@ -1,5 +1,8 @@
-FROM ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM rocker/r-ubuntu:18.04
+ARG WATCHDOG_VERSION="0.8.4"
+ARG R_IMAGE="rocker/r-ubuntu:20.04"
+
+FROM ghcr.io/openfaas/of-watchdog:${WATCHDOG_VERSION} as watchdog
+FROM ${R_IMAGE}
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
@@ -20,22 +23,14 @@ ENV _R_SHLIB_STRIP_=true
 
 # Install basic dependencies for index.R
 # some packages seem to require build from source
-RUN install2.r -e remotes
-RUN R -q -e 'install.packages(c("Rcpp", "httpuv"), repos=c(CRAN = "https://cloud.r-project.org"))'
+RUN R -q -e 'install.packages(c("Rcpp", "httpuv", "remotes"), repos=c(CRAN = "https://cloud.r-project.org"))'
 
 COPY install.R /usr/local/bin/
 
-# Create a non-root user
-RUN addgroup --system app \
-    && adduser --system --ingroup app app
-
-WORKDIR /home/app
-
-COPY index.R           .
-COPY function          .
+COPY function/DESCRIPTION     .
 
 # Istall SystemRequirements for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$sysreqs()'
 RUN echo requirements.txt
 RUN apt-get update
 RUN xargs -a requirements.txt apt-get install -y --no-install-recommends
@@ -46,7 +41,19 @@ RUN rm requirements.txt
 RUN R -q -e 'remotes::install_deps()'
 
 # Install VersionedPackages for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$versioned()'
+
+RUN rm -f ./DESCRIPTION
+
+
+# Create a non-root user
+RUN addgroup --system app \
+    && adduser --system --ingroup app app
+
+WORKDIR /home/app
+
+COPY index.R           .
+COPY function          .
 
 # Switch to app user
 RUN chown app:app -R /home/app

--- a/template/rstats-ubuntu-plumber/Dockerfile
+++ b/template/rstats-ubuntu-plumber/Dockerfile
@@ -1,5 +1,8 @@
-FROM ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM rocker/r-ubuntu:18.04
+ARG WATCHDOG_VERSION="0.8.4"
+ARG R_IMAGE="rocker/r-ubuntu:20.04"
+
+FROM ghcr.io/openfaas/of-watchdog:${WATCHDOG_VERSION} as watchdog
+FROM ${R_IMAGE}
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
@@ -24,22 +27,14 @@ ENV _R_SHLIB_STRIP_=true
 
 # Install basic dependencies for index.R
 # some packages seem to require build from source
-RUN R -q -e 'install.packages(c("Rcpp", "stringi", "httpuv"), repos=c(CRAN = "https://cloud.r-project.org"))'
-RUN install2.r -e remotes plumber
+RUN R -q -e 'install.packages(c("Rcpp", "stringi", "httpuv", "remotes", "plumber"), repos=c(CRAN = "https://cloud.r-project.org"))'
 
 COPY install.R /usr/local/bin/
 
-# Create a non-root user
-RUN addgroup --system app \
-    && adduser --system --ingroup app app
-
-WORKDIR /home/app
-
-COPY index.R           .
-COPY function          .
+COPY function/DESCRIPTION     .
 
 # Istall SystemRequirements for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$sysreqs()'
 RUN echo requirements.txt
 RUN apt-get update
 RUN xargs -a requirements.txt apt-get install -y --no-install-recommends
@@ -50,7 +45,18 @@ RUN rm requirements.txt
 RUN R -q -e 'remotes::install_deps()'
 
 # Install VersionedPackages for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$versioned()'
+
+RUN rm -f ./DESCRIPTION
+
+# Create a non-root user
+RUN addgroup --system app \
+    && adduser --system --ingroup app app
+
+WORKDIR /home/app
+
+COPY index.R           .
+COPY function          .
 
 # Switch to app user
 RUN chown app:app -R /home/app

--- a/template/rstats-ubuntu/Dockerfile
+++ b/template/rstats-ubuntu/Dockerfile
@@ -1,5 +1,8 @@
-FROM ghcr.io/openfaas/classic-watchdog:0.1.5 as watchdog
-FROM rocker/r-ubuntu:18.04
+ARG WATCHDOG_VERSION="0.1.5"
+ARG R_IMAGE="rocker/r-ubuntu:20.04"
+
+FROM ghcr.io/openfaas/classic-watchdog:${WATCHDOG_VERSION} as watchdog
+FROM ${R_IMAGE}
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
@@ -19,17 +22,10 @@ RUN R -q -e 'install.packages(c("remotes", "jsonlite"))'
 
 COPY install.R /usr/local/bin/
 
-# Create a non-root user
-RUN addgroup --system app \
-    && adduser --system --ingroup app app
-
-WORKDIR /home/app
-
-COPY index.R           .
-COPY function          .
+COPY function/DESCRIPTION     .
 
 # Istall SystemRequirements for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$sysreqs()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$sysreqs()'
 RUN echo requirements.txt
 RUN apt-get update
 RUN xargs -a requirements.txt apt-get install -y --no-install-recommends
@@ -40,7 +36,18 @@ RUN rm requirements.txt
 RUN R -q -e 'remotes::install_deps()'
 
 # Install VersionedPackages for handler.R from DESCRIPTION
-RUN R -q -e 'source("/usr/local/bin/install.R"); install$versioned()'
+RUN R -q -e 'source("/usr/local/bin/install.R");install$versioned()'
+
+RUN rm -f ./DESCRIPTION
+
+# Create a non-root user
+RUN addgroup --system app \
+    && adduser --system --ingroup app app
+
+WORKDIR /home/app
+
+COPY index.R           .
+COPY function          .
 
 # Switch to app user
 RUN chown app:app -R /home/app

--- a/test/test.sh
+++ b/test/test.sh
@@ -9,15 +9,39 @@ echo -n $PASSWORD | faas-cli login --username admin --password-stdin
 #faas-cli template pull https://github.com/analythium/openfaas-rstats-templates
 
 # Which template to use
-export TEMPLATE_NAME="rstats-base-plumber"
+#export TEMPLATE_NAME="rstats-ubuntu-plumber"
+#export TEMPLATE_NAME="rstats-ubuntu-httpuv"
+#export TEMPLATE_NAME="rstats-ubuntu-fiery"
+#export TEMPLATE_NAME="rstats-ubuntu-beakr"
+#export TEMPLATE_NAME="rstats-ubuntu-ambiorix"
+#export TEMPLATE_NAME="rstats-ubuntu"
+
+#export TEMPLATE_NAME="rstats-base-plumber"
+#export TEMPLATE_NAME="rstats-base-httpuv"
+#export TEMPLATE_NAME="rstats-base-fiery"
+#export TEMPLATE_NAME="rstats-base-beakr"
+#export TEMPLATE_NAME="rstats-base-ambiorix"
+#export TEMPLATE_NAME="rstats-base"
+
+#export TEMPLATE_NAME="rstats-minimal-plumber"
+#export TEMPLATE_NAME="rstats-minimal-httpuv"
+#export TEMPLATE_NAME="rstats-minimal-fiery"
+#export TEMPLATE_NAME="rstats-minimal-beakr"
+#export TEMPLATE_NAME="rstats-minimal-ambiorix"
+#export TEMPLATE_NAME="rstats-minimal"
 
 # Create Hello World example
 export FUNCTION_NAME=r-$TEMPLATE_NAME
 faas-cli new --lang $TEMPLATE_NAME $FUNCTION_NAME --prefix=$OPENFAAS_PREFIX
 faas-cli up -f $FUNCTION_NAME.yml
 
+# Inspect logs
+faas-cli logs $FUNCTION_NAME
+
 # Test the function
-curl $OPENFAAS_URL/function/$FUNCTION_NAME -d '"World"'
+curl $OPENFAAS_URL/function/$FUNCTION_NAME \
+  -d '"World"' \
+  -H 'Content-Type: application/json'
 
 # Remove the function and files
 faas-cli remove -f $FUNCTION_NAME.yml

--- a/test/test.sh
+++ b/test/test.sh
@@ -47,3 +47,20 @@ curl $OPENFAAS_URL/function/$FUNCTION_NAME \
 faas-cli remove -f $FUNCTION_NAME.yml
 rm $FUNCTION_NAME.yml
 rm -r $FUNCTION_NAME
+
+## --
+
+docker images --filter=reference='*/r-rstats-*' --format "{{.Repository}}\t{{.Size}}"
+
+#psolymos/r-rstats-base-plumber      927MB
+#psolymos/r-rstats-base-fiery        934MB
+#psolymos/r-rstats-base-httpuv       873MB
+#psolymos/r-rstats-base-beakr        923MB
+#psolymos/r-rstats-base-ambiorix     921MB
+#psolymos/r-rstats-base              833MB
+#psolymos/r-rstats-ubuntu-ambiorix   884MB
+#psolymos/r-rstats-ubuntu-beakr      849MB
+#psolymos/r-rstats-ubuntu            768MB
+#psolymos/r-rstats-ubuntu-fiery      860MB
+#psolymos/r-rstats-ubuntu-httpuv     804MB
+#psolymos/r-rstats-ubuntu-plumber    853MB

--- a/test/test.sh
+++ b/test/test.sh
@@ -52,15 +52,21 @@ rm -r $FUNCTION_NAME
 
 docker images --filter=reference='*/r-rstats-*' --format "{{.Repository}}\t{{.Size}}"
 
-#psolymos/r-rstats-base-plumber      927MB
+#psolymos/r-rstats-base              833MB
+#psolymos/r-rstats-base-ambiorix     921MB
+#psolymos/r-rstats-base-beakr        923MB
 #psolymos/r-rstats-base-fiery        934MB
 #psolymos/r-rstats-base-httpuv       873MB
-#psolymos/r-rstats-base-beakr        923MB
-#psolymos/r-rstats-base-ambiorix     921MB
-#psolymos/r-rstats-base              833MB
+#psolymos/r-rstats-base-plumber      927MB
+#psolymos/r-rstats-ubuntu            768MB
 #psolymos/r-rstats-ubuntu-ambiorix   884MB
 #psolymos/r-rstats-ubuntu-beakr      849MB
-#psolymos/r-rstats-ubuntu            768MB
 #psolymos/r-rstats-ubuntu-fiery      860MB
 #psolymos/r-rstats-ubuntu-httpuv     804MB
 #psolymos/r-rstats-ubuntu-plumber    853MB
+#psolymos/r-rstats-minimal           286MB
+#psolymos/r-rstats-minimal-ambiorix  488MB
+#psolymos/r-rstats-minimal-beakr     388MB
+#psolymos/r-rstats-minimal-fiery     400MB
+#psolymos/r-rstats-minimal-httpuv    349MB
+#psolymos/r-rstats-minimal-plumber   392MB


### PR DESCRIPTION
This PR rearranges the dependency management so that cache can be used more optimally, i.e. when only code changes in the `/function` folder, cache will be used instead of installing again. This is achieved by separately copying `DESCRIPTION` for installation, before the handler is copied.

Closes #38 

Closes #39 